### PR TITLE
feat : 광해 데이터 MySQL 마이그레이션 및 성능 최적화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### Custom ###
 .env
 /src/main/resources/light_pollution_korea.csv
+db
 
 HELP.md
 .gradle

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // Stargazing
     implementation 'org.shredzone.commons:commons-suncalc:3.7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,25 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 
+    // devtools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+
+    implementation 'org.hibernate.orm:hibernate-spatial'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Stargazing
     implementation 'org.shredzone.commons:commons-suncalc:3.7'
 
+    // test
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+    mysql:
+        image: mysql:8.0
+        container_name: stargazer-db
+        ports:
+            - "3306:3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: stargazer
+            MYSQL_USER: user
+            MYSQL_PASSWORD: password
+
+            TZ: Asia/Seoul
+        command:
+          # 대량 데이터 insert 시 패킷 크기 에러 방지 및 인코딩 설정
+            --character-set-server=utf8mb4
+            --collation-server=utf8mb4_unicode_ci
+            --max_allowed_packet=64M
+        volumes:
+            # DB 데이터를 로컬에 영구 저장 (컨테이너 내려도 데이터 유지)
+            - ./db/mysql/data:/var/lib/mysql
+        restart: always
+
+    redis:
+        image: redis:alpine
+        container_name: stargazer-redis
+        ports:
+            - "6379:6379"

--- a/src/main/java/xyz/ncookie/stargazer/StargazerApplication.java
+++ b/src/main/java/xyz/ncookie/stargazer/StargazerApplication.java
@@ -2,8 +2,10 @@ package xyz.ncookie.stargazer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class StargazerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/entity/LightPollution.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/entity/LightPollution.java
@@ -1,0 +1,43 @@
+package xyz.ncookie.stargazer.domain.stargazing.entity;
+
+import org.locationtech.jts.geom.Point;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "light_pollution", indexes = {
+	@Index(name = "idx_location", columnList = "location")
+})
+public class LightPollution {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// SRID 4326 (WGS84 - 위도/경도 좌표계) 명시
+	@Column(columnDefinition = "POINT SRID 4326", nullable = false)
+	private Point location;
+
+	// 광해 등급
+	@Column(nullable = false)
+	private int bortleClass;
+
+	private double radiance;
+
+	public LightPollution(Point location, int bortleClass, double radiance) {
+		this.location = location;
+		this.bortleClass = bortleClass;
+		this.radiance = radiance;
+	}
+}

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/provider/LightPollutionDataProvider.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/provider/LightPollutionDataProvider.java
@@ -1,85 +1,31 @@
 package xyz.ncookie.stargazer.domain.stargazing.provider;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.stereotype.Component;
 
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.stereotype.Service;
-
-import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import xyz.ncookie.stargazer.domain.stargazing.entity.LightPollution;
+import xyz.ncookie.stargazer.domain.stargazing.repository.LightPollutionRepository;
 
-@Service
+@Component
+@RequiredArgsConstructor
 @Slf4j
 public class LightPollutionDataProvider {
 
-	// 메모리 검색을 위한 Map (Key: "lat_idx,lon_idx", Value: BortleClass)
-	// 0.01도(약 1.1km) 단위로 격자를 나눔
-	private final Map<String, Integer> lightPollutionMap = new HashMap<>();
-	private static final double GRID_SIZE = 0.01; // 정밀도 조절 (0.01 = 1km)
-
-	@PostConstruct
-	public void loadData() {
-		try {
-			log.info("광해 데이터(CSV) 로딩 시작...");
-			ClassPathResource resource = new ClassPathResource("light_pollution_korea.csv");
-
-			// 파일이 없으면 더미 데이터라도 로드 (에러 방지)
-			if (!resource.exists()) {
-				log.warn("광해 데이터 파일이 없습니다. 기본값으로 동작합니다.");
-				return;
-			}
-
-			try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
-				String line;
-				boolean isHeader = true;
-				while ((line = br.readLine()) != null) {
-					if (isHeader) { isHeader = false; continue; } // 헤더 스킵
-
-					String[] parts = line.split(",");
-					if (parts.length < 3) continue;
-
-					double lat = Double.parseDouble(parts[0]);
-					double lon = Double.parseDouble(parts[1]);
-					int bortle = Integer.parseInt(parts[2]);
-
-					// 좌표를 격자 키로 변환 (예: 37.573 -> "3757")
-					String key = generateKey(lat, lon);
-					lightPollutionMap.put(key, bortle);
-				}
-			}
-			log.info("광해 데이터 로딩 완료. (총 {}개 지점)", lightPollutionMap.size());
-		} catch (Exception e) {
-			log.error("광해 데이터 로딩 중 에러 발생", e);
-		}
-	}
+	private final LightPollutionRepository lightPollutionRepository;
 
 	/**
 	 * 특정 좌표의 Bortle 등급 조회
-	 * 데이터가 없으면 '주변 탐색'을 하거나 기본값 반환
 	 */
 	public int getBortleClass(double lat, double lon) {
-		String key = generateKey(lat, lon);
 
-		// 1. 정확히 일치하는 격자가 있으면 반환
-		if (lightPollutionMap.containsKey(key)) {
-			return lightPollutionMap.get(key);
-		}
+		// Point 객체 생성 포맷: "POINT(경도 위도)"
+		String pointText = String.format("POINT(%f %f)", lat, lon);
+		
+		return lightPollutionRepository.findNearest(pointText)
+			.map(LightPollution::getBortleClass)
+			.orElse(4);	// 데이터가 없다면 중간값(4)로 처리
 
-		// 2. 데이터가 없다면? (바다, 혹은 데이터 누락 지역)
-		// -> 안전하게 4 (시골) 또는 주소 기반 로직(fallback) 호출 필요
-		// 여기서는 간단히 주변 9칸을 검색하는 로직을 추가할 수 있음
-		return 4; // 기본값 (데이터 없을 때)
-	}
-
-	// 좌표 -> 격자 Key 변환 (소수점 2자리 버림)
-	// 37.1234 -> 3712
-	private String generateKey(double lat, double lon) {
-		long latIdx = Math.round(lat / GRID_SIZE);
-		long lonIdx = Math.round(lon / GRID_SIZE);
-		return latIdx + "," + lonIdx;
+		// 데이터가 없다면 추후 주변 9칸을 검색하는 로직 등을 추가할 수 있음
 	}
 }

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/provider/LightPollutionDataProvider.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/provider/LightPollutionDataProvider.java
@@ -1,5 +1,6 @@
 package xyz.ncookie.stargazer.domain.stargazing.provider;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class LightPollutionDataProvider {
 	/**
 	 * 특정 좌표의 Bortle 등급 조회
 	 */
+	@Cacheable(value = "bortleZone", key = "#lat + '-' + #lon")
 	public int getBortleClass(double lat, double lon) {
 
 		// Point 객체 생성 포맷: "POINT(경도 위도)"

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/provider/LightPollutionDataProvider.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/provider/LightPollutionDataProvider.java
@@ -21,10 +21,7 @@ public class LightPollutionDataProvider {
 	@Cacheable(value = "bortleZone", key = "#lat + '-' + #lon")
 	public int getBortleClass(double lat, double lon) {
 
-		// Point 객체 생성 포맷: "POINT(경도 위도)"
-		String pointText = String.format("POINT(%f %f)", lat, lon);
-		
-		return lightPollutionRepository.findNearest(pointText)
+		return lightPollutionRepository.findNearest(lat, lon)
 			.map(LightPollution::getBortleClass)
 			.orElse(4);	// 데이터가 없다면 중간값(4)로 처리
 

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/repository/LightPollutionRepository.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/repository/LightPollutionRepository.java
@@ -1,0 +1,21 @@
+package xyz.ncookie.stargazer.domain.stargazing.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import xyz.ncookie.stargazer.domain.stargazing.entity.LightPollution;
+
+@Repository
+public interface LightPollutionRepository extends JpaRepository<LightPollution, Long> {
+
+	@Query(value = """
+		SELECT * FROM light_pollution lp
+		ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText(:point, 4326)) ASC
+        LIMIT 1
+	""", nativeQuery = true)
+	Optional<LightPollution> findNearest(@Param("point") String pointText);
+}

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/repository/LightPollutionRepository.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/repository/LightPollutionRepository.java
@@ -13,17 +13,23 @@ import xyz.ncookie.stargazer.domain.stargazing.entity.LightPollution;
 public interface LightPollutionRepository extends JpaRepository<LightPollution, Long> {
 
 	/**
-	 * 1. WHERE MBRContains(...) : 인덱스를 사용해 주변(약 11km) 반경의 데이터만 1차로 필터링
-	 * 2. ORDER BY ... : 걸러진 소수의 데이터 중에서만 정밀 거리 계산 수행
+	 * ST_Buffer 대신 ST_MakeEnvelope 사용
+	 * 이유: 원을 그리는 것보다 사각형을 만드는 게 훨씬 빠름 (CPU 절약)
+	 * 범위: 내 위치 기준 ±0.1도 (약 10km x 10km 박스)
 	 */
 	@Query(value = """
         SELECT * FROM light_pollution lp
         WHERE MBRContains(
-            ST_Buffer(ST_GeomFromText(:point, 4326), 10000), -- 0.1도 반경 (약 10km) 버퍼 생성
+            ST_SRID( -- 만들어진 사각형에 SRID 4326 부여 (필수!)
+                ST_MakeEnvelope(
+                    POINT(:lon - 0.1, :lat - 0.1), -- 좌측 하단 (Min X, Min Y)
+                    POINT(:lon + 0.1, :lat + 0.1)  -- 우측 상단 (Max X, Max Y)
+                ), 
+            4326),
             lp.location
         )
-        ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText(:point, 4326)) ASC
+        ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText(CONCAT('POINT(', :lat, ' ', :lon, ')'), 4326)) ASC
         LIMIT 1
     """, nativeQuery = true)
-	Optional<LightPollution> findNearest(@Param("point") String pointText);
+	Optional<LightPollution> findNearest(@Param("lat") double lat, @Param("lon") double lon);
 }

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/repository/LightPollutionRepository.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/repository/LightPollutionRepository.java
@@ -12,10 +12,18 @@ import xyz.ncookie.stargazer.domain.stargazing.entity.LightPollution;
 @Repository
 public interface LightPollutionRepository extends JpaRepository<LightPollution, Long> {
 
+	/**
+	 * 1. WHERE MBRContains(...) : 인덱스를 사용해 주변(약 11km) 반경의 데이터만 1차로 필터링
+	 * 2. ORDER BY ... : 걸러진 소수의 데이터 중에서만 정밀 거리 계산 수행
+	 */
 	@Query(value = """
-		SELECT * FROM light_pollution lp
-		ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText(:point, 4326)) ASC
+        SELECT * FROM light_pollution lp
+        WHERE MBRContains(
+            ST_Buffer(ST_GeomFromText(:point, 4326), 10000), -- 0.1도 반경 (약 10km) 버퍼 생성
+            lp.location
+        )
+        ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText(:point, 4326)) ASC
         LIMIT 1
-	""", nativeQuery = true)
+    """, nativeQuery = true)
 	Optional<LightPollution> findNearest(@Param("point") String pointText);
 }

--- a/src/main/java/xyz/ncookie/stargazer/domain/stargazing/service/StargazingService.java
+++ b/src/main/java/xyz/ncookie/stargazer/domain/stargazing/service/StargazingService.java
@@ -30,6 +30,7 @@ import xyz.ncookie.stargazer.domain.stargazing.enums.BortleGrade;
 import xyz.ncookie.stargazer.domain.stargazing.enums.MoonPhase;
 import xyz.ncookie.stargazer.domain.stargazing.model.StarAnalysisResult;
 import xyz.ncookie.stargazer.domain.stargazing.enums.VisibilityGrade;
+import xyz.ncookie.stargazer.infra.lightpollution.LightPollutionMigrationRunner;
 
 @Service
 @Slf4j
@@ -43,6 +44,8 @@ public class StargazingService {
 	private final StargazingScoringEngine scoringEngine;
 
 	private final OpenWeatherResponseMapper openWeatherResponseMapper;
+
+	private final LightPollutionMigrationRunner runner;
 
 	/**
 	 * 특정 시점(현재 또는 미래)의 관측 적합도 상세 분석

--- a/src/main/java/xyz/ncookie/stargazer/infra/lightpollution/LightPollutionMigrationRunner.java
+++ b/src/main/java/xyz/ncookie/stargazer/infra/lightpollution/LightPollutionMigrationRunner.java
@@ -1,0 +1,82 @@
+package xyz.ncookie.stargazer.infra.lightpollution;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import xyz.ncookie.stargazer.domain.stargazing.entity.LightPollution;
+import xyz.ncookie.stargazer.domain.stargazing.repository.LightPollutionRepository;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LightPollutionMigrationRunner implements CommandLineRunner {
+
+	private final LightPollutionRepository repository;
+	private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+	@Override
+	public void run(String @NonNull ... args) throws Exception {
+		if (repository.count() > 0) {
+			log.error("광해 데이터가 이미 존재합니다. 마이그레이션을 건너뜁니다.");
+			return;
+		}
+
+		log.info("광해 데이터 마이그레이션 시작...");
+		long startTime = System.currentTimeMillis();
+
+		ClassPathResource resource = new ClassPathResource("light_pollution_korea.csv");
+		List<LightPollution> batchList = new ArrayList<>();
+		int batchSize = 1000;
+
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
+			String line;
+			boolean isHeader = true;
+
+			while ((line = br.readLine()) != null) {
+				if (isHeader) { isHeader = false; continue; } // 헤더 스킵
+
+				String[] parts = line.split(",");
+				if (parts.length < 4) continue;
+
+				try {
+					double lat = Double.parseDouble(parts[0]);
+					double lon = Double.parseDouble(parts[1]);
+					double radiance = Double.parseDouble(parts[2]);
+					int bortle = Integer.parseInt(parts[3]);
+
+					Point point = geometryFactory.createPoint(new Coordinate(lon, lat));
+					batchList.add(new LightPollution(point, bortle, radiance));
+
+					if (batchList.size() >= batchSize) {
+						repository.saveAll(batchList);
+						batchList.clear();
+					}
+				} catch (Exception e) {
+					log.error("Skipping line: " + line);
+				}
+
+			}
+		}
+
+		if (!batchList.isEmpty()) {
+			repository.saveAll(batchList);
+		}
+
+		long endTime = System.currentTimeMillis();
+		log.info("광해 데이터 DB 이관 완료! (소요시간: {}ms)%n", (endTime - startTime));
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.application.name=stargazer
-
-weather.api.key=${WEATHER_API_KEY}
-
-gemini.api.key=${LLM_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,11 @@ spring:
                 # 포맷팅된 SQL 로그 보기 (개발용)
                 format_sql: true
 
+    cache:
+        type: caffeine
+        caffeine:
+            spec: maximumSize=500, expireAfterWrite=10m # 최대 500개, 쓴 지 10분 뒤 삭제
+
 weather:
     api:
         key: ${WEATHER_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+spring:
+    application:
+        name: stargazer
+
+    datasource:
+        url: jdbc:mysql://localhost:3306/stargazer?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+        username: user
+        password: password
+        driver-class-name: com.mysql.cj.jdbc.Driver
+
+    jpa:
+        hibernate:
+            ddl-auto: update
+        properties:
+            hibernate:
+                # 중요: MySQL 8 버전에 맞는 Dialect 사용 (Spatial 자동 지원)
+                dialect: org.hibernate.dialect.MySQLDialect
+                # 포맷팅된 SQL 로그 보기 (개발용)
+                format_sql: true
+
+weather:
+    api:
+        key: ${WEATHER_API_KEY}
+
+gemini:
+    api:
+        key: ${LLM_API_KEY}


### PR DESCRIPTION
## 📋 PR 개요

기존에 메모리(CSV 로드) 방식으로 관리하던 광해(Light Pollution) 데이터를 **MySQL Spatial DB(GIS)**로 이관하고, 대용량 좌표 데이터의 검색 성능을 최적화했습니다.
데이터 양이 증가함에 따라 발생할 수 있는 **OOM(Out Of Memory) 이슈를 방지**하고, **공간 인덱스(R-Tree)**를 활용하여 확장성을 확보하는 것이 목적입니다.

## 🎯 변경 사항

* [x] **Entity 및 Repository 구현**: `LightPollution` 엔티티 정의 및 `POINT` 타입(SRID 4326) 적용
* [x] **데이터 마이그레이션 로직 구현**: `CommandLineRunner`를 통해 앱 구동 시 CSV 데이터를 DB로 배치(`Batch Insert`) 적재
* [x] **공간 쿼리 최적화**: `ST_MakeEnvelope`를 활용한 MBR(Minimum Bounding Rectangle) 필터링 적용
* [x] **로컬 캐시 적용**: `Caffeine` 캐시를 도입하여 반복적인 DB 조회 부하 제거

## 🔧 기술적 변경 사항

* **의존성 추가**:
  * `org.hibernate.orm:hibernate-spatial`: 공간 데이터 처리를 위한 하이버네이트 모듈
  * `com.github.ben-manes.caffeine:caffeine`: 고성능 로컬 캐싱 라이브러리

* **DB 스키마**: `POINT` 컬럼에 `SRID 4326(WGS84)`을 적용하여 GPS 좌표계 표준을 준수했습니다.
* **쿼리 성능 튜닝**:
  * 단순 `ST_Distance_Sphere` 사용 시 Full Table Scan으로 인한 성능 저하(약 600ms) 발생
  * **MBR(사각형 영역) 필터링**(`ST_MakeEnvelope`)을 선행하여 후보군을 좁힌 후 정밀 거리를 계산하도록 개선 (**약 10ms, 60배 성능 향상**)

* **좌표계 이슈 해결**: MySQL 8.0의 SRID 4326 표준에 따라 WKT 문자열 생성 시 `(Lat, Lon)` 순서를 준수하도록 로직을 수정했습니다.

## 📸 스크린샷/데모

**[성능 개선 결과]**

**Query Execution Time 비교:** 593 ms -> 10ms (약 60배)

```
[2026-01-04 17:28:06] stargazer> SELECT * FROM light_pollution lp ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText('POINT(37.5665 126.978)', 4326)) ASC LIMIT 1
[2026-01-04 17:28:07] 1 row retrieved starting from 1 in 924 ms (execution: 593 ms, fetching: 331 ms)
[2026-01-04 17:28:07] stargazer> SELECT * FROM light_pollution lp
                                 WHERE MBRContains(
                                               ST_Buffer(ST_GeomFromText('POINT(37.5665 126.978)', 4326), 10000),
                                               lp.location
                                       )
                                 ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText('POINT(37.5665 126.978)', 4326)) ASC
                                 LIMIT 1
[2026-01-04 17:28:08] 1 row retrieved starting from 1 in 742 ms (execution: 18 ms, fetching: 724 ms)
[2026-01-04 17:28:08] stargazer> SELECT * FROM light_pollution lp
                                 WHERE MBRContains(
                                               ST_SRID(
                                                       ST_MakeEnvelope(
                                                           -- 여기서는 POINT(경도, 위도) 순서입니다! (X=Lon, Y=Lat)
                                                               POINT(126.978 - 0.1, 37.5665 - 0.1), -- 좌측 하단 (Min Lon, Min Lat)
                                                               POINT(126.978 + 0.1, 37.5665 + 0.1)  -- 우측 상단 (Max Lon, Max Lat)
                                                       ),
                                                       4326),
                                               lp.location
                                       )
                                 ORDER BY ST_Distance_Sphere(lp.location, ST_GeomFromText('POINT(37.5665 126.978)', 4326)) ASC
                                 LIMIT 1
[2026-01-04 17:28:09] 1 row retrieved starting from 1 in 710 ms (execution: 10 ms, fetching: 700 ms)

```

## ✅ 체크리스트

* [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
* [x] 자체적으로 코드 리뷰를 수행했습니다
* [x] 코드에 주석을 추가했습니다 (특히 복잡한 부분)
* [x] 문서를 업데이트했습니다 (필요한 경우)
* [x] 변경 사항이 새로운 경고를 생성하지 않습니다
* [x] 새로운 테스트를 추가했습니다 (필요한 경우)
* [x] 새로운 테스트와 기존 테스트가 모두 통과합니다
* [x] 의존성이 올바르게 추가/업데이트되었습니다

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 링크해주세요 (예: #123) -->
- #5 