### PR TITLE
fix: CORS 설정 업데이트 - 로컬 및 프로덕션 Swagger 허용 추가

### DIFF
--- a/src/main/java/xyz/ncookie/stargazer/global/config/SecurityConfig.java
+++ b/src/main/java/xyz/ncookie/stargazer/global/config/SecurityConfig.java
@@ -98,7 +98,9 @@ public class SecurityConfig {
 
 		config.setAllowedOrigins(List.of(
 			"http://localhost:3000",
-			"https://www.byeolbolil.xyz"
+			"http://localhost:8080",      // 로컬 Swagger
+			"https://www.byeolbolil.xyz",
+			"https://api.byeolbolil.xyz"  // 프로덕션 Swagger
 		));
 
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 📋 PR 개요

- 배포된 도메인의 swagger에서 요청을 시도하면 CORS 에러가 발생함
- Spring Security config에서 swagger 도메인의 origin을 허용 리스트에 넣지 않아서 발생한 문제라고 추측되어 해당 코드를 수정함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * CORS 설정이 개선되어 로컬 개발 환경 및 프로덕션 도메인에서 교차 출처 요청이 올바르게 처리되도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->